### PR TITLE
types(Character): region is optional

### DIFF
--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -74,7 +74,7 @@ export interface Character {
   gender: string;
   substat: string;
   affiliation: string;
-  region: string;
+  region?: string;
   rarity: number;
   birthday: [number, number];
   constellation: string;


### PR DESCRIPTION
It's optional for the Traveler and Aloy, for example.